### PR TITLE
[codex] Fix checkout E2E tests

### DIFF
--- a/app/components/richText.tsx
+++ b/app/components/richText.tsx
@@ -91,7 +91,7 @@ const richTextOptions = ({
                 />
                 <div className='grid grid-cols-2 lg:grid-cols-3 gap-4'>
                   {cakesGroup.cakesCollection?.items?.map(cake => {
-                    if (!cake) return null
+                    if (!cake?.sys?.id) return null
 
                     const typePrice = (type: 'A' | 'B' | 'C') => {
                       const price = cake[`type${type}Price`]

--- a/app/components/richText.tsx
+++ b/app/components/richText.tsx
@@ -26,11 +26,13 @@ const richTextOptions = ({
   const assetMap = new Map()
   if (links?.assets?.block) {
     for (const asset of links.assets.block) {
+      if (!asset?.sys?.id) continue
       assetMap.set(asset.sys?.id, asset)
     }
   }
   if (links?.assets?.hyperlink) {
     for (const asset of links.assets.hyperlink) {
+      if (!asset?.sys?.id) continue
       assetMap.set(asset.sys?.id, asset)
     }
   }
@@ -38,6 +40,7 @@ const richTextOptions = ({
   const entryMap = new Map()
   if (links?.entries?.block) {
     for (const entry of links.entries?.block) {
+      if (!entry?.sys?.id) continue
       entryMap.set(entry.sys?.id, entry)
     }
   }
@@ -45,7 +48,8 @@ const richTextOptions = ({
   return {
     renderNode: {
       [BLOCKS.EMBEDDED_ASSET]: node => {
-        const asset = assetMap.get(node.data.target.sys.id) as CommonImage
+        const targetId = node.data.target?.sys?.id
+        const asset = targetId ? (assetMap.get(targetId) as CommonImage) : undefined
         if (!asset) return
 
         return (
@@ -62,7 +66,8 @@ const richTextOptions = ({
         )
       },
       [BLOCKS.EMBEDDED_ENTRY]: node => {
-        const entry = entryMap.get(node.data.target.sys.id)
+        const targetId = node.data.target?.sys?.id
+        const entry = targetId ? entryMap.get(targetId) : undefined
         if (!entry) return null
 
         switch (entry.__typename) {
@@ -86,6 +91,8 @@ const richTextOptions = ({
                 />
                 <div className='grid grid-cols-2 lg:grid-cols-3 gap-4'>
                   {cakesGroup.cakesCollection?.items?.map(cake => {
+                    if (!cake) return null
+
                     const typePrice = (type: 'A' | 'B' | 'C') => {
                       const price = cake[`type${type}Price`]
                       const unit = cake[`type${type}Unit`]
@@ -154,20 +161,22 @@ const richTextOptions = ({
                   `lg:${columns(grid.columnsLarge)}`
                 )}
               >
-                {grid.assetsCollection?.items.map((asset, index) => (
-                  <figure key={index} className='my-0 lg:my-auto'>
-                    <Image
-                      alt={asset.title}
-                      image={asset}
-                      width={assetWidth || 432}
-                      quality={85}
-                      className={classNames(asset.description ? 'mb-0' : '', 'mx-auto')}
-                    />
-                    {asset.description && (
-                      <figcaption className='mt-1'>{asset.description}</figcaption>
-                    )}
-                  </figure>
-                ))}
+                {grid.assetsCollection?.items.map((asset, index) =>
+                  asset ? (
+                    <figure key={index} className='my-0 lg:my-auto'>
+                      <Image
+                        alt={asset.title}
+                        image={asset}
+                        width={assetWidth || 432}
+                        quality={85}
+                        className={classNames(asset.description ? 'mb-0' : '', 'mx-auto')}
+                      />
+                      {asset.description && (
+                        <figcaption className='mt-1'>{asset.description}</figcaption>
+                      )}
+                    </figure>
+                  ) : null
+                )}
               </div>
             )
           default:
@@ -182,7 +191,8 @@ const richTextOptions = ({
         )
       },
       [INLINES.ASSET_HYPERLINK]: node => {
-        const asset = assetMap.get(node.data.target.sys.id)
+        const targetId = node.data.target?.sys?.id
+        const asset = targetId ? assetMap.get(targetId) : undefined
         if (!asset) return
 
         return (

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,10 +2,10 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
-  fullyParallel: true,
+  fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: 1,
-  workers: 5,
+  workers: process.env.CI ? 1 : 5,
   reporter: 'html',
   timeout: 60000,
   expect: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: 1,
   workers: process.env.CI ? 1 : 5,
   reporter: 'html',
-  timeout: 60000,
+  timeout: 180000,
   expect: {
     timeout: 10000
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     }
   ],
   webServer: {
-    command: 'npm run dev',
+    command: 'CHOKIDAR_USEPOLLING=true npm run dev',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120000

--- a/tests/e2e/checkout.spec.ts
+++ b/tests/e2e/checkout.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, Page } from '@playwright/test'
-import { STRIPE_TEST_CARD, TEST_SHIPPING_ADDRESS, TEST_EMAIL, TEST_PHONE } from './fixtures'
+import {
+  STRIPE_TEST_CARD,
+  TEST_PRODUCT_PATHS,
+  TEST_SHIPPING_ADDRESS,
+  TEST_EMAIL,
+  TEST_PHONE
+} from './fixtures'
 
 /**
  * Helper to complete the Stripe payment form
@@ -146,13 +152,7 @@ async function addCakeToBag(page: Page, options: {
 }) {
   const { cakeType, selectAmount = 1, deliveryType } = options
 
-  if (cakeType === 'normal') {
-    await page.goto('/cake/may-roll')
-  } else if (cakeType === 'birthday') {
-    await page.goto('/cake/birthday-cake-no-6')
-  } else if (cakeType === 'shipping') {
-    await page.goto('/cake/japanese-hojicha-powder-50g')
-  }
+  await page.goto(TEST_PRODUCT_PATHS[cakeType])
 
   await page.waitForLoadState('networkidle')
 

--- a/tests/e2e/checkout.spec.ts
+++ b/tests/e2e/checkout.spec.ts
@@ -112,11 +112,19 @@ async function completeStripePayment(
     await billingNameInput.fill(TEST_SHIPPING_ADDRESS.name)
   }
 
+  // Keep Stripe's card validation deterministic across runner locales.
+  const billingCountrySelect = page
+    .locator('select#billingCountry, select[name="billingCountry"], select[name="billingAddressCountry"]')
+    .first()
+  if (await billingCountrySelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await billingCountrySelect.selectOption('US')
+  }
+
   // Fill billing postal code (ZIP) if visible - Stripe may require this for card validation
   // The input may have various names depending on the Stripe checkout version
   const billingPostalInput = page.locator('input[name="billingPostalCode"], input[placeholder*="ZIP"], input[placeholder*="Postal"]').first()
   if (await billingPostalInput.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await billingPostalInput.fill(TEST_SHIPPING_ADDRESS.postalCode)
+    await billingPostalInput.fill('12345')
   }
 
   // Click pay button

--- a/tests/e2e/checkout.spec.ts
+++ b/tests/e2e/checkout.spec.ts
@@ -138,110 +138,74 @@ async function addCakeToBag(page: Page, options: {
 }) {
   const { cakeType, selectAmount = 1, deliveryType } = options
 
-  await page.goto('/')
-  
-  // Click the appropriate navigation link
   if (cakeType === 'normal') {
-    // Click on "Cakes & Sweets" link
-    await page.getByRole('link', { name: /cakes.*sweets/i }).click()
+    await page.goto('/cake/may-roll')
   } else if (cakeType === 'birthday') {
-    // Click on "Birthday Cakes" link
-    await page.getByRole('link', { name: /birthday/i }).click()
+    await page.goto('/cake/birthday-cake-no-6')
   } else if (cakeType === 'shipping') {
     await page.goto('/cake/japanese-hojicha-powder-50g')
   }
 
   await page.waitForLoadState('networkidle')
 
-  // For listing pages, find links and navigate to individual cake pages.
-  const cakeLinks = cakeType === 'shipping'
-    ? page.locator('body')
-    : page.locator('a[href^="/cake/"]')
-  const cakeLinkCount = await cakeLinks.count()
-  
-  // Iterate through cakes to find one that is in stock
-  let addedToBag = false
+  const amountSelect = page.locator('select[name="amount"]')
+  const isAvailable = await amountSelect.isVisible({ timeout: 5000 }).catch(() => false)
 
-  for (let i = 0; i < cakeLinkCount; i++) {
-    // Click the cake
-    if (cakeType !== 'shipping') {
-      await cakeLinks.nth(i).click()
-      await page.waitForURL(/\/cake\//)
-      await page.waitForLoadState('networkidle')
-    }
-
-    // Check if the amount selector is visible (indicating item is in stock)
-    const amountSelect = page.locator('select[name="amount"]')
-    const isAvailable = await amountSelect.isVisible({ timeout: 2000 }).catch(() => false)
-
-    if (isAvailable) {
-      // If a delivery option is needed, select the delivery type and any required date.
-      if (deliveryType) {
-        const deliverySelect = page.locator('select[name="delivery"]')
-        if (await deliverySelect.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await deliverySelect.selectOption(deliveryType)
-          await page.waitForTimeout(500)
-
-          const dateInput = page.locator('input[placeholder="Select date ..."]')
-          if (await dateInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-            await dateInput.click()
-            await page.waitForTimeout(500)
-
-            const availableDay = page.locator('button.rdp-day_button:not([disabled])').first()
-            if (await availableDay.isVisible({ timeout: 3000 }).catch(() => false)) {
-              await availableDay.click()
-              await page.waitForTimeout(500)
-            }
-          }
-        }
-      }
-
-      // Select amount
-      await amountSelect.selectOption(selectAmount.toString())
-
-      // Handle any customization selects (e.g., "Paper tag" on birthday cakes and some normal cakes)
-      // Look for selects that have a placeholder option with "..." indicating they need selection
-      const customSelects = page.locator('select').filter({ has: page.locator('option:has-text("...")') })
-      const count = await customSelects.count()
-
-      for (let j = 0; j < count; j++) {
-        const select = customSelects.nth(j)
-        const selectName = await select.getAttribute('name')
-        // Skip standard selects
-        if (selectName === 'amount' || selectName === 'unit' || selectName === 'delivery') continue
-
-        // Get all options except disabled ones
-        const options = select.locator('option:not([disabled])')
-        const optionCount = await options.count()
-        if (optionCount > 0) {
-          const firstValue = await options.first().getAttribute('value')
-          if (firstValue) {
-            await select.selectOption(firstValue)
-          }
-        }
-      }
-
-      // Click "Add to bag"
-      await page.getByRole('button', { name: 'Add to bag' }).click()
-
-      // Wait for the bag to update
-      await page.waitForTimeout(500)
-
-      addedToBag = true
-      break // Exit loop as we successfully added a cake
-    } else {
-      if (cakeType === 'shipping') break
-
-      // If not available, go back to the listing page
-      await page.goBack()
-      await page.waitForLoadState('networkidle')
-      // Continue to next cake
-    }
-  }
-  
-  if (!addedToBag) {
+  if (!isAvailable) {
     throw new Error(`No available ${cakeType} product found to add to bag.`)
   }
+
+  // If a delivery option is needed, select the delivery type and any required date.
+  if (deliveryType) {
+    const deliverySelect = page.locator('select[name="delivery"]')
+    if (await deliverySelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await deliverySelect.selectOption(deliveryType)
+      await page.waitForTimeout(500)
+
+      const dateInput = page.locator('input[placeholder="Select date ..."]')
+      if (await dateInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await dateInput.click()
+        await page.waitForTimeout(500)
+
+        const availableDay = page.locator('button.rdp-day_button:not([disabled])').first()
+        if (await availableDay.isVisible({ timeout: 3000 }).catch(() => false)) {
+          await availableDay.click()
+          await page.waitForTimeout(500)
+        }
+      }
+    }
+  }
+
+  // Select amount
+  await amountSelect.selectOption(selectAmount.toString())
+
+  // Handle any customization selects (e.g., "Paper tag" on birthday cakes and some normal cakes)
+  // Look for selects that have a placeholder option with "..." indicating they need selection
+  const customSelects = page.locator('select').filter({ has: page.locator('option:has-text("...")') })
+  const count = await customSelects.count()
+
+  for (let j = 0; j < count; j++) {
+    const select = customSelects.nth(j)
+    const selectName = await select.getAttribute('name')
+    // Skip standard selects
+    if (selectName === 'amount' || selectName === 'unit' || selectName === 'delivery') continue
+
+    // Get all options except disabled ones
+    const options = select.locator('option:not([disabled])')
+    const optionCount = await options.count()
+    if (optionCount > 0) {
+      const firstValue = await options.first().getAttribute('value')
+      if (firstValue) {
+        await select.selectOption(firstValue)
+      }
+    }
+  }
+
+  // Click "Add to bag"
+  await page.getByRole('button', { name: 'Add to bag' }).click()
+
+  // Wait for the bag to update
+  await page.waitForTimeout(500)
 }
 
 /**
@@ -303,6 +267,8 @@ async function completeCheckoutFromBag(page: Page, options: {
 }
 
 test.describe('Checkout E2E Tests', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeEach(async ({ page }) => {
     // Clear localStorage to start fresh
     await page.goto('/')

--- a/tests/e2e/checkout.spec.ts
+++ b/tests/e2e/checkout.spec.ts
@@ -132,7 +132,7 @@ async function completeStripePayment(
  * Helper to navigate to a specific cake page and add to bag
  */
 async function addCakeToBag(page: Page, options: {
-  cakeType: 'normal' | 'birthday' | 'giftcard'
+  cakeType: 'normal' | 'birthday' | 'shipping'
   selectAmount?: number
   deliveryType?: 'pickup' | 'shipping'
 }) {
@@ -147,41 +147,16 @@ async function addCakeToBag(page: Page, options: {
   } else if (cakeType === 'birthday') {
     // Click on "Birthday Cakes" link
     await page.getByRole('link', { name: /birthday/i }).click()
-  } else if (cakeType === 'giftcard') {
-    // Click on "Gift card" link  
-    await page.getByRole('link', { name: /gift.*card/i }).click()
+  } else if (cakeType === 'shipping') {
+    await page.goto('/cake/japanese-hojicha-powder-50g')
   }
 
   await page.waitForLoadState('networkidle')
 
-  // Gift card is displayed inline on the page, not as a link to /cake/...
-  if (cakeType === 'giftcard') {
-    // The gift card form is directly on the /gift-card page
-    const amountSelect = page.locator('select[name="amount"]')
-    await amountSelect.waitFor({ state: 'visible', timeout: 5000 })
-
-    // If delivery option is needed
-    if (deliveryType) {
-      const deliverySelect = page.locator('select[name="delivery"]')
-      if (await deliverySelect.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await deliverySelect.selectOption(deliveryType)
-        await page.waitForTimeout(500)
-      }
-    }
-
-    // Select amount
-    await amountSelect.selectOption(selectAmount.toString())
-
-    // Click "Add to bag"
-    await page.getByRole('button', { name: 'Add to bag' }).click()
-
-    // Wait for the bag to update
-    await page.waitForTimeout(500)
-    return
-  }
-
-  // For normal cakes and birthday cakes, find links and navigate to individual cake pages
-  const cakeLinks = page.locator('a[href^="/cake/"]')
+  // For listing pages, find links and navigate to individual cake pages.
+  const cakeLinks = cakeType === 'shipping'
+    ? page.locator('body')
+    : page.locator('a[href^="/cake/"]')
   const cakeLinkCount = await cakeLinks.count()
   
   // Iterate through cakes to find one that is in stock
@@ -189,21 +164,35 @@ async function addCakeToBag(page: Page, options: {
 
   for (let i = 0; i < cakeLinkCount; i++) {
     // Click the cake
-    await cakeLinks.nth(i).click()
-    await page.waitForURL(/\/cake\//)
-    await page.waitForLoadState('networkidle')
+    if (cakeType !== 'shipping') {
+      await cakeLinks.nth(i).click()
+      await page.waitForURL(/\/cake\//)
+      await page.waitForLoadState('networkidle')
+    }
 
     // Check if the amount selector is visible (indicating item is in stock)
     const amountSelect = page.locator('select[name="amount"]')
     const isAvailable = await amountSelect.isVisible({ timeout: 2000 }).catch(() => false)
 
     if (isAvailable) {
-      // If delivery option is needed (like for gift cards with shipping)
+      // If a delivery option is needed, select the delivery type and any required date.
       if (deliveryType) {
         const deliverySelect = page.locator('select[name="delivery"]')
         if (await deliverySelect.isVisible({ timeout: 2000 }).catch(() => false)) {
           await deliverySelect.selectOption(deliveryType)
           await page.waitForTimeout(500)
+
+          const dateInput = page.locator('input[placeholder="Select date ..."]')
+          if (await dateInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+            await dateInput.click()
+            await page.waitForTimeout(500)
+
+            const availableDay = page.locator('button.rdp-day_button:not([disabled])').first()
+            if (await availableDay.isVisible({ timeout: 3000 }).catch(() => false)) {
+              await availableDay.click()
+              await page.waitForTimeout(500)
+            }
+          }
         }
       }
 
@@ -241,6 +230,8 @@ async function addCakeToBag(page: Page, options: {
       addedToBag = true
       break // Exit loop as we successfully added a cake
     } else {
+      if (cakeType === 'shipping') break
+
       // If not available, go back to the listing page
       await page.goBack()
       await page.waitForLoadState('networkidle')
@@ -249,7 +240,7 @@ async function addCakeToBag(page: Page, options: {
   }
   
   if (!addedToBag) {
-    throw new Error(`No available ${cakeType} cakes found to add to bag.`)
+    throw new Error(`No available ${cakeType} product found to add to bag.`)
   }
 }
 
@@ -346,10 +337,10 @@ test.describe('Checkout E2E Tests', () => {
     await expect(page.getByText(/thank you for your order/i)).toBeVisible()
   })
 
-  test('3. Purchase a giftcard with pickup in store', async ({ page }) => {
-    // Add gift card with pickup to bag
+  test('3. Purchase a shippable product with pickup in store', async ({ page }) => {
+    // Add shippable product with pickup to bag
     await addCakeToBag(page, { 
-      cakeType: 'giftcard', 
+      cakeType: 'shipping',
       selectAmount: 1,
       deliveryType: 'pickup'
     })
@@ -364,10 +355,56 @@ test.describe('Checkout E2E Tests', () => {
     await expect(page.getByText(/thank you for your order/i)).toBeVisible()
   })
 
-  test('4. Purchase a giftcard with delivery to Netherlands', async ({ page }) => {
-    // Add gift card with shipping to bag
+  /*
+   * Gift card purchase flows are temporarily disabled because the current CMS
+   * gift-card page no longer exposes a purchasable order form. Re-enable these
+   * when gift cards are introduced back as an orderable item.
+   *
+   * test('3. Purchase a giftcard with pickup in store', async ({ page }) => {
+   *   await addCakeToBag(page, {
+   *     cakeType: 'giftcard',
+   *     selectAmount: 1,
+   *     deliveryType: 'pickup'
+   *   })
+   *
+   *   await completeCheckoutFromBag(page, { hasPickupItems: true })
+   *   await completeStripePayment(page)
+   *   await expect(page.getByText(/thank you for your order/i)).toBeVisible()
+   * })
+   *
+   * test('4. Purchase a giftcard with delivery to Netherlands', async ({ page }) => {
+   *   await addCakeToBag(page, {
+   *     cakeType: 'giftcard',
+   *     selectAmount: 1,
+   *     deliveryType: 'shipping'
+   *   })
+   *
+   *   await completeCheckoutFromBag(page, { hasShippingItems: true })
+   *   await completeStripePayment(page, { withShipping: true })
+   *   await expect(page.getByText(/thank you for your order/i)).toBeVisible()
+   * })
+   *
+   * test('5. Purchase a birthday cake AND a giftcard with delivery', async ({ page }) => {
+   *   await addCakeToBag(page, { cakeType: 'birthday', selectAmount: 1 })
+   *   await addCakeToBag(page, {
+   *     cakeType: 'giftcard',
+   *     selectAmount: 1,
+   *     deliveryType: 'shipping'
+   *   })
+   *
+   *   await completeCheckoutFromBag(page, {
+   *     hasPickupItems: true,
+   *     hasShippingItems: true
+   *   })
+   *   await completeStripePayment(page, { withShipping: true })
+   *   await expect(page.getByText(/thank you for your order/i)).toBeVisible()
+   * })
+   */
+
+  test('4. Purchase a shippable product with delivery to Netherlands', async ({ page }) => {
+    // Add shippable product with shipping to bag
     await addCakeToBag(page, { 
-      cakeType: 'giftcard', 
+      cakeType: 'shipping',
       selectAmount: 1,
       deliveryType: 'shipping'
     })
@@ -382,13 +419,13 @@ test.describe('Checkout E2E Tests', () => {
     await expect(page.getByText(/thank you for your order/i)).toBeVisible()
   })
 
-  test('5. Purchase a birthday cake AND a giftcard with delivery', async ({ page }) => {
+  test('5. Purchase a birthday cake AND a shippable product with delivery', async ({ page }) => {
     // First: Add birthday cake (pickup)
     await addCakeToBag(page, { cakeType: 'birthday', selectAmount: 1 })
 
-    // Second: Add gift card with shipping
+    // Second: Add shippable product with shipping
     await addCakeToBag(page, { 
-      cakeType: 'giftcard', 
+      cakeType: 'shipping',
       selectAmount: 1,
       deliveryType: 'shipping'
     })

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -16,3 +16,9 @@ export const TEST_SHIPPING_ADDRESS = {
 
 export const TEST_EMAIL = 'test@example.com'
 export const TEST_PHONE = '+31612345678'
+
+export const TEST_PRODUCT_PATHS = {
+  normal: '/cake/may-roll',
+  birthday: '/cake/birthday-cake-no-6',
+  shipping: '/cake/japanese-hojicha-powder-50g'
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,10 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
     plugins: [
-        cloudflare({ viteEnvironment: { name: "ssr" } }),
+        cloudflare({
+            inspectorPort: false,
+            viteEnvironment: { name: "ssr" }
+        }),
         reactRouter(),
         tailwindcss(),
         tsconfigPaths()
@@ -14,7 +17,20 @@ export default defineConfig({
     server: {
         port: 5173,
         strictPort: true,
-        open: false
+        open: false,
+        watch: {
+            ignored: [
+                "**/.git/**",
+                "**/.react-router/**",
+                "**/.wrangler/**",
+                "**/build/**",
+                "**/node_modules/**",
+                "**/playwright-report/**",
+                "**/public/build/**",
+                "**/test-results/**",
+                "**/tmp/**"
+            ]
+        }
     },
     build: {
         sourcemap: false


### PR DESCRIPTION
## Summary

- Make the local Playwright web server start reliably by reducing Vite/Cloudflare watcher pressure and disabling the Workers inspector during dev startup.
- Harden Contentful rich-text rendering against null linked entries/assets so CMS drift does not blank pages.
- Update checkout E2E coverage to use a current shippable product while preserving the old gift-card flows as commented templates for reuse when gift cards become orderable again.

## Root Cause

The E2E suite was blocked first by local dev server startup failures (`EMFILE` from file watchers). Once the browser could run, current CMS content no longer exposed a purchasable gift-card form, and null linked Contentful entries could crash rich-text rendering.

## Validation

- `npm run test:e2e` passed: 5 tests
- `npm test` passed: 33 tests

## Notes

`npm run typecheck` still fails on existing `app/utils/stock-update.test.ts` TypeScript issues around `global` and implicit `any`; those are unrelated to this PR.