### PR TITLE
Fix Playwright setup while keeping E2E trigger pattern

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 
 on:
-  check_run:
+  check_suite:
     types:
       - completed
   workflow_dispatch:
@@ -15,19 +15,22 @@ jobs:
       (
         github.event_name == 'workflow_dispatch'
       ) || (
-        github.event.check_run.conclusion == 'success' &&
-        github.event.check_run.check_suite.head_branch == 'main' &&
-        github.event.check_run.name == 'Workers Builds: rar-website'
+        github.event.check_suite.conclusion == 'success' &&
+        github.event.check_suite.head_branch == 'main' &&
+        contains(github.event.check_suite.app.name, 'Cloudflare')
       )
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      options: --user 1001
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository for automatic run
-        if: github.event_name == 'check_run'
+        if: github.event_name == 'check_suite'
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.check_run.head_sha }}
+          ref: ${{ github.event.check_suite.head_sha }}
 
       - name: Checkout repository for manual run
         if: github.event_name == 'workflow_dispatch'
@@ -41,9 +44,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
 
       - name: Run E2E tests
         run: npm run test:e2e
@@ -59,7 +59,7 @@ jobs:
           WEBHOOK_STRIPE_SIGNING_SECRET_PREVIEW: ${{ secrets.WEBHOOK_STRIPE_SIGNING_SECRET_PREVIEW }}
 
       - name: Promote Worker version
-        if: github.event_name == 'check_run'
+        if: github.event_name == 'check_suite'
         run: |
           VERSION_ID="$(
             npx wrangler versions list --json | node -e 'const fs = require("node:fs");
@@ -78,7 +78,7 @@ jobs:
           --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          VERSION_TAG: ${{ github.event.check_run.head_sha }}
+          VERSION_TAG: ${{ github.event.check_suite.head_sha }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 
 on:
-  check_suite:
+  check_run:
     types:
       - completed
   workflow_dispatch:
@@ -15,9 +15,9 @@ jobs:
       (
         github.event_name == 'workflow_dispatch'
       ) || (
-        github.event.check_suite.conclusion == 'success' &&
-        github.event.check_suite.head_branch == 'main' &&
-        contains(github.event.check_suite.app.name, 'Cloudflare')
+        github.event.check_run.conclusion == 'success' &&
+        github.event.check_run.check_suite.head_branch == 'main' &&
+        github.event.check_run.name == 'Workers Builds: rar-website'
       )
     runs-on: ubuntu-latest
     container:
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository for automatic run
-        if: github.event_name == 'check_suite'
+        if: github.event_name == 'check_run'
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.check_suite.head_sha }}
+          ref: ${{ github.event.check_run.head_sha }}
 
       - name: Checkout repository for manual run
         if: github.event_name == 'workflow_dispatch'
@@ -59,7 +59,7 @@ jobs:
           WEBHOOK_STRIPE_SIGNING_SECRET_PREVIEW: ${{ secrets.WEBHOOK_STRIPE_SIGNING_SECRET_PREVIEW }}
 
       - name: Promote Worker version
-        if: github.event_name == 'check_suite'
+        if: github.event_name == 'check_run'
         run: |
           VERSION_ID="$(
             npx wrangler versions list --json | node -e 'const fs = require("node:fs");
@@ -78,7 +78,7 @@ jobs:
           --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          VERSION_TAG: ${{ github.event.check_suite.head_sha }}
+          VERSION_TAG: ${{ github.event.check_run.head_sha }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
-      options: --user 1001
+      options: --user 1001 --ipc=host
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary

- Keep the automatic E2E trigger aligned with the proven Terra workflow pattern: `check_run: completed` plus exact check-run-name filtering.
- Use the RAR-specific Cloudflare Workers Build check name: `Workers Builds: rar-website`.
- Run Playwright in the official Microsoft Playwright Docker image matching the locked `@playwright/test` version (`1.57.0`), so the workflow no longer downloads Chromium during the job.

## Reference pattern

`terradelft-website` uses:

```yaml
on:
  check_run:
    types:
      - completed

if: >-
  github.event.check_run.conclusion == 'success' &&
  github.event.check_run.check_suite.head_branch == 'main' &&
  github.event.check_run.name == 'Workers Builds: terradelft-website'
```

This PR keeps the same shape for `rar-website` and only changes the Playwright browser setup path.